### PR TITLE
handle connection failures on the builds page

### DIFF
--- a/home/dfhack/www/builds/builds.css
+++ b/home/dfhack/www/builds/builds.css
@@ -138,6 +138,30 @@ a {
 	background-color: #ccc;
 }
 
+#status {
+	position: relative;
+	min-height: 30rem;
+}
+
+#disconnected {
+	display: none;
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	z-index: 10;
+	text-align: center;
+	background-color: rgba(127, 127, 127, 0.4);
+}
+
+#reconnecting, #reconnect {
+	position: sticky;
+	top: 50%;
+	font-size: 3rem;
+	padding: 1rem;
+}
+
 @media (prefers-color-scheme: dark) {
 html {
 	background: #222;

--- a/home/dfhack/www/builds/index.html
+++ b/home/dfhack/www/builds/index.html
@@ -26,7 +26,12 @@
         </section>
     </header>
     <noscript>JavaScript is required to render the live build viewer.</noscript>
-    <div id="status"></div>
+    <div id="status">
+	    <div id="disconnected">
+		    <div id="reconnecting">Attempting to connect to the DFHack build server...</div>
+		    <button id="reconnect">Lost connection. Click here to reconnect.</button>
+	    </div>
+    </div>
     <script src="builds.js"></script>
 </body>
 </html>


### PR DESCRIPTION
for browsers that support the Page Visibility API, it will automatically
reconnect once per minute in the case of a hard connection error (one
where the browser does not decide to automatically reconnect to the
event source). if the page is not visible, reconnecting is delayed until
the page becomes visible.

when there is not an active connection or an in-progress connection
attempt, a button is displayed to allow the user to reconnect.